### PR TITLE
Sketch upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Ignore mtb build folder
 /mtb-libs/build
 /mtb-libs/bsps
+mtb_shared
  
 # Ignore files built by Visual Studio/Visual Micro
 [Dd]ebug/

--- a/boards.txt
+++ b/boards.txt
@@ -27,7 +27,11 @@ CY8CKIT-062S2-AI-Kit.upload.openocdpath={runtime.tools.openocd.path}
 
 # Upload settings
 CY8CKIT-062S2-AI-Kit.upload.tool=openocd
+# Not sure if we need all these parameters -> Ramya?
+# {
 CY8CKIT-062S2-AI-Kit.upload.protocol=openocd
 CY8CKIT-062S2-AI-Kit.upload.maximum_size=2097152
 CY8CKIT-062S2-AI-Kit.upload.speed=115200
 CY8CKIT-062S2-AI-Kit.communication=usb
+# }
+CY8CKIT-062S2-AI-Kit.upload.target_openocd_cfg=psoc6_2m.cfg

--- a/platform.txt
+++ b/platform.txt
@@ -40,6 +40,7 @@ compiler.arduino_core_dep.path={compiler.arduino_core.path}/deprecated
 compiler.arduino_core_dep_avr.path={compiler.arduino_core.path}/deprecated-avr-comp/avr
 compiler.arduino_core_api.path= "-I{compiler.arduino_core_dep_avr.path}" "-I{compiler.arduino_core_dep.path}"  "-I{compiler.arduino_core.path}" 
 
+
 # GCC related definitions
 compiler.c.flags=-mtune={build.mcu} -c -g -Os {compiler.warning_flags} -std=gnu11  -nostdlib --param max-inline-insns-single=500 -MMD
 compiler.c.extra_flags=
@@ -87,8 +88,9 @@ recipe.hooks.prebuild.6.pattern=python {runtime.platform.path}/tools/mtb_build_i
 compiler.flags.from_file=@{build.mtb_libs_board_build_path}/compiler_flags.txt
 compiler.elf_flags.from_file=@{build.mtb_libs_board_build_path}/linker_flags.txt
 
+
 # Includes
-includes=-I{build.path}/cores/psoc
+includes=-I{build.path}/cores/psoc 
 
 # Build commands
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} "{compiler.flags.from_file}" {compiler.arduino_core_api.path} {includes} "{source_file}" -o "{object_file}"
@@ -116,7 +118,7 @@ recipe.size.regex=^(\.text|\.eh_frame)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.data|\.VENEER_Code|\.ram_code|\.bss|\.no_init|\Stack)\s+([0-9]+).*
 
 # Create output files
-# ----------------
+# -------------------
 
 ## Create output (bin file)
 recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags}"{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
@@ -124,3 +126,25 @@ recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf
 ## Save hex
 recipe.output.tmp_file={build.project_name}.bin
 recipe.output.save_file={build.project_name}.{build.variant}.bin
+
+# Upload .hex file
+# ----------------
+
+tools.openocd.path={runtime.tools.ModusToolbox.path}/openocd
+tools.openocd.program_ext.linux=
+tools.openocd.program_ext.windows=.exe
+tools.openocd.program={path}/bin/openocd{program_ext}
+# A BSP might have additional openocd config files in its GeneratedSources path
+tools.openocd.board_cfg_search_path={runtime.platform.path}/mtb-libs/bsps/TARGET_APP_{build.variant}/config/GeneratedSource
+# openocd config files search paths
+tools.openocd.search_paths=-s {path}/scripts -s {board_cfg_search_path}
+# openocd requires the adapter serial number to distinguish when multiple boards are connected
+# This is provided by the serial discovery properties of the selected upload port
+tools.openocd.serial_adapter=adapter serial {upload.port.properties.serialNumber}
+# openocd program command to flash the built .hex 
+tools.openocd.command=-c "source [find interface/kitprog3.cfg]; {serial_adapter} ; source [find target/{upload.target_openocd_cfg}]; psoc6 allow_efuse_program off; psoc6 sflash_restrictions 1; program {build.path}/{build.project_name}.hex verify reset exit;"
+# By default openocd is verbose with debug level 2
+tools.openocd.upload.params.verbose= 
+# For quiet mode, the output is stored in a openocd.log file in the build path
+tools.openocd.upload.params.quiet=-l {build.path}/{build.project_name}.openocd.log
+tools.openocd.upload.pattern={program} {upload.verbose} {search_paths} {command}


### PR DESCRIPTION
* Added **_upload_ command** based on openocd tool.
* The right port will be selected for flashing when multiple Kitprog3 devices are connected 😃.
* The --verbose option will print the -debug level mode 2 (default) openocd flashing progress.
* The --quiet (default) option log the output in a file in the build temp folder.

**Instructions to test** (so far I have only done in the arduino-cli wsl)

- Make sure the udev_rules are enabled: ~/.arduino15/packages/Infineon-psoc/tools/ModusToolbox/tools_3.2/fw-loader/udev_rules/install_rules.sh
For an "example/example.ino" file:
- `arduino-cli compile --clean -b Infineon-psoc:psoc:CY8CKIT-062S2-AI-Kit ./example/example.ino`
- `arduino-cli upload --fqbn Infineon-psoc:psoc:CY8CKIT-062S2-AI-Kit -p /dev/ttyACM0 example/example.ino [--verbose]`

**What is missing?**
- Get rid of the openocd banner (I haven´t found a way to silent it directly from openocd) 

![image](https://github.com/user-attachments/assets/7224bb30-28e5-4b3c-bf77-ffaff2f98191)
Only the last "New Port Upload: /dev/ttyACM0 (serial)" should appear.

- Add post_install script in Linux for the following : 
    ~/.arduino15/packages/Infineon-psoc/tools/ModusToolbox/tools_3.2/fw-loader/udev_rules/install_rules.sh ✔️ 
    ~/.arduino15/packages/Infineon-psoc/tools/ModusToolbox/tools_3.2/driver_media/install_rules.sh ❌ ?
    -~/.arduino15/packages/Infineon-psoc/tools/ModusToolbox/tools_3.2/modus-shell/postinstall ❌ ?
     It should be necessary only when installing the package. In WSL this needs to be run all the time we start wsl (I think) -->  to check in a native distribution like ubuntu)
- Openocd error handling for arduino user readabilty:
![image](https://github.com/user-attachments/assets/3bfe785a-daf8-4e80-bed5-4da25ba89b5b)
For example, this happens when the board is not connected. We can add some hints (as we do in micropython). For all those things we need a script. 
