### PR TITLE
Upload script refactor

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -134,7 +134,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.bin
 
 tools.openocd.upload.params.verbose=-v
 tools.openocd.upload.params.quiet=
-tools.openocd.upload.params.args=upload {runtime.tools.ModusToolbox.path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target_openocd_cfg} {build.project_name} {upload.verbose}
+tools.openocd.upload.params.args=upload {runtime.tools.ModusToolbox.path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target.cfg} {build.project_name} {upload.verbose}
 
 tools.openocd.upload.pattern.linux=bash {runtime.platform.path}/tools/upload.sh {upload.params.args}
 tools.openocd.upload.pattern.windows={runtime.platform.path}/tools/upload.bat {upload.params.args}

--- a/platform.txt
+++ b/platform.txt
@@ -132,8 +132,9 @@ recipe.output.save_file={build.project_name}.{build.variant}.bin
 # Upload .hex file
 # ----------------
 
-tools.openocd.path={runtime.tools.ModusToolbox.path}/openocd
-tools.openocd.shell.linux=bash
 tools.openocd.upload.params.verbose=-v
 tools.openocd.upload.params.quiet=
-tools.openocd.upload.pattern= {shell} {runtime.platform.path}/tools/upload.sh upload {path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target_openocd_cfg} {build.project_name} {upload.verbose}
+tools.openocd.upload.params.args=upload {runtime.tools.ModusToolbox.path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target_openocd_cfg} {build.project_name} {upload.verbose}
+
+tools.openocd.upload.pattern.linux=bash {runtime.platform.path}/tools/upload.sh {upload.params.args}
+tools.openocd.upload.pattern.windows={runtime.platform.path}/tools/upload.bat {upload.params.args}

--- a/platform.txt
+++ b/platform.txt
@@ -133,20 +133,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.bin
 # ----------------
 
 tools.openocd.path={runtime.tools.ModusToolbox.path}/openocd
-tools.openocd.program_ext.linux=
-tools.openocd.program_ext.windows=.exe
-tools.openocd.program={path}/bin/openocd{program_ext}
-# A BSP might have additional openocd config files in its GeneratedSources path
-tools.openocd.board_cfg_search_path={runtime.platform.path}/mtb-libs/bsps/TARGET_APP_{build.variant}/config/GeneratedSource
-# openocd config files search paths
-tools.openocd.search_paths=-s {path}/scripts -s {board_cfg_search_path}
-# openocd requires the adapter serial number to distinguish when multiple boards are connected
-# This is provided by the serial discovery properties of the selected upload port
-tools.openocd.serial_adapter=adapter serial {upload.port.properties.serialNumber}
-# openocd program command to flash the built .hex 
-tools.openocd.command=-c "source [find interface/kitprog3.cfg]; {serial_adapter} ; source [find target/{upload.target.cfg}]; psoc6 allow_efuse_program off; psoc6 sflash_restrictions 1; program {build.path}/{build.project_name}.hex verify reset exit;"
-# By default openocd is verbose with debug level 2
-tools.openocd.upload.params.verbose= 
-# For quiet mode, the output is stored in a openocd.log file in the build path
-tools.openocd.upload.params.quiet=-l {build.path}/{build.project_name}.openocd.log
-tools.openocd.upload.pattern={program} {upload.verbose} {search_paths} {command}
+tools.openocd.shell.linux=bash
+tools.openocd.upload.params.verbose=-v
+tools.openocd.upload.params.quiet=
+tools.openocd.upload.pattern= {shell} {runtime.platform.path}/tools/upload.sh upload {path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target_openocd_cfg} {build.project_name} {upload.verbose}

--- a/tools/mtb_build_info.py
+++ b/tools/mtb_build_info.py
@@ -77,6 +77,8 @@ def get_inc_dirs(inc_dirs_file, mtb_libs_path, out_path):
 
     # Add the mtb-libs path to the include directories
     inc_list_with_updated_path = [inc_dir.replace("-I","-I"+str(mtb_libs_path)+"/") for inc_dir in inc_list_list]
+    # If windows path, replace backslashes with forward slashes
+    inc_list_with_updated_path = [inc_dir.replace("\\", "/") for inc_dir in inc_list_with_updated_path]
     print(*inc_list_with_updated_path)
 
     # Join the list into a single string with spaces between flags and write into a file

--- a/tools/upload.bat
+++ b/tools/upload.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal enabledelayedexpansion
+
+
+REM Get the arguments passed in the command line
+
+REM Command
+set upload_cmd=%1
+
+REM Paths
+set mtb_tools_path=%2
+set platform_path=%3
+set build_path=%4
+
+REM Board parameters 
+set board_variant=%5
+set board_serial_num=%6
+set board_openocd_cfg=%7
+
+REM Project parameters
+set project_name=%8
+
+REM "Optional arguments"
+REM To access 10th argument, we need to shift
+set verbose_flag=%9
+
+REM Replace backslashes with forward slashes
+REM for openocd to work properly
+set "mtb_tools_path=!mtb_tools_path:\=/!"
+set "platform_path=!platform_path:\=/!"
+set "build_path=!build_path:\=/!"
+
+%mtb_tools_path%/modus-shell/bin/bash -i -l -c "bash %platform_path%/tools/upload.sh %upload_cmd% %mtb_tools_path% %platform_path% %build_path% %board_variant% %board_serial_num% %board_openocd_cfg% %project_name% %verbose_flag%"

--- a/tools/upload.bat
+++ b/tools/upload.bat
@@ -1,7 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
 
-
 REM Get the arguments passed in the command line
 
 REM Command
@@ -21,7 +20,6 @@ REM Project parameters
 set project_name=%8
 
 REM "Optional arguments"
-REM To access 10th argument, we need to shift
 set verbose_flag=%9
 
 REM Replace backslashes with forward slashes

--- a/tools/upload.sh
+++ b/tools/upload.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# Command
+upload_cmd=$1
+
+# Paths
+openocd_path=$2
+platform_path=$3
+build_path=$4
+
+# Board parameters
+board_variant=$5
+board_serial_num=$6
+board_openocd_cfg=$7
+
+# Project parameters
+project_name=$8
+
+# Optional arguments
+verbose_flag=$9
+
+function get_openocd_exe {
+    openocd_exe="${openocd_path}/bin/openocd"
+    # Depending on the OS, the openocd executable 
+    # file extension changes.
+    # Add ".exe" extension if the OS is Windows or cygwin
+    if [[ "$OSTYPE" == "msys" ]]; then
+        openocd_exe="${openocd_exe}.exe"
+    fi
+    echo ${openocd_exe}
+}
+
+function get_openocd_search_paths {
+    # openocd config files search paths
+    # A board support package might have additional openocd config files in its GeneratedSources path
+    search_paths="-s ${openocd_path}/scripts -s ${platform_path}/mtb-libs/bsps/TARGET_APP_${board_variant}/config/GeneratedSource"
+    echo ${search_paths}
+}
+
+function get_openocd_cmd {
+    # openocd program verify reset exit command.
+    # The target controller openocd configuration ${board_openocd_cfg} file is provided by the board.
+    # The serial adapter number ${board_serial_num} is provided to ensure the right board is flashed in case of multiple KitProg3s connected.       
+    openocd_cmd="-c \"source [find interface/kitprog3.cfg]; adapter serial ${board_serial_num}; source [find target/${board_openocd_cfg}]; psoc6 allow_efuse_program off; psoc6 sflash_restrictions 1; program ${build_path}/${project_name}.hex verify reset exit;\""
+    echo ${openocd_cmd}
+}
+
+function get_openocd_log {
+    # For quiet mode, the output is stored in a openocd.log file in the build path
+    openocd_log="-l ${build_path}/${project_name}.openocd.log"
+    if [[ ${verbose_flag} == "-v" ]]; then
+        openocd_log=""
+    fi
+    echo ${openocd_log}
+}
+
+function get_upload_pattern {
+    openocd_exe=$(get_openocd_exe)
+    search_paths=$(get_openocd_search_paths)
+    openocd_cmd=$(get_openocd_cmd)  
+    openocd_log=$(get_openocd_log)
+    upload_pattern="${openocd_exe} ${search_paths} ${openocd_cmd} ${openocd_log}"
+    echo ${upload_pattern}
+}
+
+function print_upload_pattern {
+    upload_pattern=$1
+    echo "-----------------------------------------"
+    echo "Openocd sketch upload pattern: "
+    echo
+    echo ${upload_pattern}
+    echo
+    echo "-----------------------------------------"
+}
+
+function parse_upload_err_code {
+    error_code=$1
+
+    # if error code is 0, the upload was successful
+    if [[ ${error_code} == 0 ]]; then
+        exit 0
+    fi
+
+    # Try to provide a more helpful error message
+    # by inspecting the openocd log file
+    openocd_log="${build_path}/${project_name}.openocd.log"
+
+    # Search for the error message in the openocd log file
+    error=$(grep "Error:" "${openocd_log}")
+
+    # Known error messages
+    cmsis_dap_device_not_found="Error: unable to find a matching CMSIS-DAP device"
+
+    # Display user friendly message for kwnon errors
+    # Otherwise, display the error message
+    case ${error} in
+        ${cmsis_dap_device_not_found})
+            error_message="Are you sure the board is connected?"
+            ;;
+        *)
+            error_message="${error}"
+            ;;
+
+    esac
+
+    # Error message in red
+    red="\e[31m"
+    reset_color=$(tput sgr0)
+    echo -e "${red}${error_message}${reset_color}"
+
+    exit 1
+}
+
+function upload {
+    upload_pattern=$(get_upload_pattern)
+    # This will hide the openocd banner, 
+    # which is even printer when using log file output
+    hide_output="> /dev/null"
+
+    if [[ ${verbose_flag} == "-v" ]]; then
+        print_args
+        print_upload_pattern "${upload_pattern}"
+        hide_output=""
+    fi
+
+    eval ${upload_pattern} ${hide_output}
+
+    parse_upload_err_code $?
+}
+
+function help {
+    echo "Usage: "
+    echo 
+    echo "  bash upload.sh upload <openocd_path> <platform_path> <build_path> <board_variant> <board_serial_num> <board_openocd_cfg> <project_name> [-v]"
+    echo "  bash upload.sh help"
+    echo
+    echo "Positional arguments for 'upload' command:"
+    echo 
+    echo "  openocd_path          Path to the openocd package directory"
+    echo "  platform_path         Path to the platform directory"
+    echo "  build_path            Path to the build directory"
+    echo
+    echo "  board_variant         Board variant (OPN name)"
+    echo "  board_serial_num      Serial adapter number (KitProg3)"
+    echo "  board_openocd_cfg     Board target controller openocd configuration file"
+    echo
+    echo "  project_name          Sketch .hex file name"
+
+    echo "Optional arguments:"
+    echo
+    echo "  -v                    Verbose mode. Default is quiet mode which save output in log file."
+}
+
+function print_args {
+    echo "-----------------------------------------"
+    echo "Upload script arguments"
+    echo
+    echo "Paths"
+    echo "-----"
+    echo "openocd_path       ${openocd_path}"
+    echo "platform_path      ${platform_path}"
+    echo "build_path         ${build_path}"
+    echo
+    echo "Board parameters"
+    echo "----------------"
+    echo "board_variant      ${board_variant}"
+    echo "board_serial_num   ${board_serial_num}"
+    echo "board_openocd_cfg  ${board_openocd_cfg}"
+    echo
+    echo "Project parameters"
+    echo "------------------"
+    echo "project_name       ${project_name}"
+    echo
+    echo "Optional arguments"
+    echo "------------------"
+    echo "verbose_flag       ${verbose_flag}"
+    echo
+    echo "-----------------------------------------"
+}
+
+case ${upload_cmd} in
+    "upload")
+        upload
+        ;;
+   "help")
+        help
+        ;;
+   *)
+        help
+        exit 1
+        ;;
+esac

--- a/tools/upload.sh
+++ b/tools/upload.sh
@@ -21,12 +21,6 @@ verbose_flag=$9
 
 function get_openocd_exe {
     openocd_exe="${mtb_tools_path}/openocd/bin/openocd"
-    # Depending on the OS, the openocd executable 
-    # file extension changes.
-    # Add ".exe" extension if the OS is Windows or cygwin
-    if [[ "$OSTYPE" == "msys" ]]; then
-        openocd_exe="${openocd_exe}.exe"
-    fi
     echo ${openocd_exe}
 }
 

--- a/tools/upload.sh
+++ b/tools/upload.sh
@@ -4,7 +4,7 @@
 upload_cmd=$1
 
 # Paths
-openocd_path=$2
+mtb_tools_path=$2
 platform_path=$3
 build_path=$4
 
@@ -20,7 +20,7 @@ project_name=$8
 verbose_flag=$9
 
 function get_openocd_exe {
-    openocd_exe="${openocd_path}/bin/openocd"
+    openocd_exe="${mtb_tools_path}/openocd/bin/openocd"
     # Depending on the OS, the openocd executable 
     # file extension changes.
     # Add ".exe" extension if the OS is Windows or cygwin
@@ -33,7 +33,7 @@ function get_openocd_exe {
 function get_openocd_search_paths {
     # openocd config files search paths
     # A board support package might have additional openocd config files in its GeneratedSources path
-    search_paths="-s ${openocd_path}/scripts -s ${platform_path}/mtb-libs/bsps/TARGET_APP_${board_variant}/config/GeneratedSource"
+    search_paths="-s ${mtb_tools_path}/openocd/scripts -s ${platform_path}/mtb-libs/bsps/TARGET_APP_${board_variant}/config/GeneratedSource"
     echo ${search_paths}
 }
 
@@ -114,7 +114,7 @@ function parse_upload_err_code {
 function upload {
     upload_pattern=$(get_upload_pattern)
     # This will hide the openocd banner, 
-    # which is even printer when using log file output
+    # which is even printed when using log file output
     hide_output="> /dev/null"
 
     if [[ ${verbose_flag} == "-v" ]]; then
@@ -131,12 +131,12 @@ function upload {
 function help {
     echo "Usage: "
     echo 
-    echo "  bash upload.sh upload <openocd_path> <platform_path> <build_path> <board_variant> <board_serial_num> <board_openocd_cfg> <project_name> [-v]"
+    echo "  bash upload.sh upload <mtb_tools_path> <platform_path> <build_path> <board_variant> <board_serial_num> <board_openocd_cfg> <project_name> [-v]"
     echo "  bash upload.sh help"
     echo
     echo "Positional arguments for 'upload' command:"
     echo 
-    echo "  openocd_path          Path to the openocd package directory"
+    echo "  mtb_tools_path        Path to the MTB tools directory"
     echo "  platform_path         Path to the platform directory"
     echo "  build_path            Path to the build directory"
     echo
@@ -157,7 +157,7 @@ function print_args {
     echo
     echo "Paths"
     echo "-----"
-    echo "openocd_path       ${openocd_path}"
+    echo "mtb_tools_path     ${mtb_tools_path}"
     echo "platform_path      ${platform_path}"
     echo "build_path         ${build_path}"
     echo


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

This PR addresses the following topics:
- Path slashes issues in windows environment solved by .bat file and modifications in get_build_flags.py script (this one is anyhow to be refactor to avoid python dependency).
- Cleanup, simplified and more modular platform.txt for upload recipe.
- Bash script with the following features:
   - Verbose mode: prints all arguments, command line openocd call and openocd output
   - Quiet (default) mode: openocd output saved in a log file in build folder.
   - help document all positional and optional arguments.
   - Error parser helper to parse openocd errors into user friendly messages (coloured in red).