### PR TITLE
Remove package json consumption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,26 +44,30 @@ jobs:
     # These are the steps which should run for each combination of fqbn and example code
     steps:
 
-      - name: Install/Update Arduino Platform
-        run: |
-          arduino-cli core update-index
-          arduino-cli core install ${{ matrix.platform }} --additional-urls https://github.com/Infineon/arduino-core-psoc/releases/latest/download/package_psoc_index.json 
-          arduino-cli core list
-
-      - name: Remove latest installed platform version
-        run: |
-          cd ~/.arduino15/packages/infineon/hardware/psoc
-          rm -rf *
-
       - name: Checkout repository 
         uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Generate package json
+        run: |
+          python ./tools/release.py build-local
+
+      - name: copy package json
+        run: |
+          cp -af ~/actions-runner/_work/arduino-core-psoc/arduino-core-psoc/pkg_build/package_psoc_index.json ~/.arduino15
+  
+
+      - name: Install/Update Arduino Platform
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install ${{ matrix.platform }}
+          arduino-cli core list
       
-      # - name: Setup environment
-      #   run: |
-      #     export REPO="$(basename "$GITHUB_REPOSITORY")"
-      #     bash ./tools/dev-setup.sh git_submodule_setup
+      - name: Remove latest installed platform version
+        run: |
+          cd ~/.arduino15/packages/infineon/hardware/psoc
+          rm -rf *
 
       - name: copy/link repository to arduino path
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,18 +52,24 @@ jobs:
       - name: Generate package json
         run: |
           python ./tools/release.py build-local
-
-      - name: copy package json
-        run: |
-          cp -af ~/actions-runner/_work/arduino-core-psoc/arduino-core-psoc/pkg_build/package_psoc_index.json ~/.arduino15
   
-
+      - name: Start local HTTP server
+        run: |
+          cd pkg_build
+          nohup python -m http.server 8000 & echo $! > server.pid
+        
       - name: Install/Update Arduino Platform
         run: |
           arduino-cli core update-index
-          arduino-cli core install ${{ matrix.platform }}
+          arduino-cli core install ${{ matrix.platform }} --additional-urls http://localhost:8000/package_psoc_index.json
           arduino-cli core list
       
+      - name: Kill local HTTP server
+        run: |
+          cd pkg_build
+          kill $(cat server.pid)
+          rm server.pid
+
       - name: Remove latest installed platform version
         run: |
           cd ~/.arduino15/packages/infineon/hardware/psoc
@@ -71,14 +77,14 @@ jobs:
 
       - name: copy/link repository to arduino path
         run: |
-          mkdir ~/.arduino15/packages/infineon/hardware/psoc/0.1.0-build
-          cp -a ~/actions-runner/_work/arduino-core-psoc/arduino-core-psoc/* ~/.arduino15/packages/infineon/hardware/psoc/0.1.0-build
-          cd ~/.arduino15/packages/infineon/hardware/psoc/0.1.0-build
+          mkdir ~/.arduino15/packages/infineon/hardware/psoc/0.0.0
+          cp -a ./* ~/.arduino15/packages/infineon/hardware/psoc/0.0.0
+          cd ~/.arduino15/packages/infineon/hardware/psoc/0.0.0
 
       - name: copy/link arduino core api path
         run: |
-          mkdir ~/.arduino15/packages/infineon/hardware/psoc/0.1.0-build/cores/psoc/api
-          cp -a ~/.arduino15/packages/infineon/hardware/psoc/0.1.0-build/extras/arduino-core-api/api/* ~/.arduino15/packages/infineon/hardware/psoc/0.1.0-build/cores/psoc/api
+          mkdir ~/.arduino15/packages/infineon/hardware/psoc/0.0.0/cores/psoc/api
+          cp -a ~/.arduino15/packages/infineon/hardware/psoc/0.0.0/extras/arduino-core-api/api/* ~/.arduino15/packages/infineon/hardware/psoc/0.0.0/cores/psoc/api
 
       # Compile the sample code for the selected board and board support package with the arduino compiler
       - name: Compile Sketch

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Ignore build folder
 /build
+/pkg_build
 
 # Ignore mtb build folder
 /mtb-libs/build
@@ -38,3 +39,4 @@ debug_custom.json
 
 # Arduino core api symlinked
 cores/psoc/api
+

--- a/package/package_psoc_index.template.json
+++ b/package/package_psoc_index.template.json
@@ -26,16 +26,16 @@
                     "toolsDependencies": [
                         {
                             "packager": "infineon",
-                            "name": "mtb-tools",
-                            "version": "3.2.0.16028"
+                            "name": "ModusToolbox",
+                            "version": "tools_3.2.0.16028"
                         }
                     ]
                 }
             ],
             "tools": [
                 {
-                    "name": "mtb-tools",
-                    "version": "3.2.0.16028",
+                    "name": "ModusToolbox",
+                    "version": "tools_3.2.0.16028",
                     "systems": [
                         {
                             "host": "i686-mingw32",

--- a/package/package_psoc_index.template.json
+++ b/package/package_psoc_index.template.json
@@ -26,7 +26,7 @@
                     "toolsDependencies": [
                         {
                             "packager": "infineon",
-                            "name": "ModusToolbox",
+                            "name": "mtb-tools",
                             "version": "tools_3.2.0.16028"
                         }
                     ]
@@ -34,7 +34,7 @@
             ],
             "tools": [
                 {
-                    "name": "ModusToolbox",
+                    "name": "mtb-tools",
                     "version": "tools_3.2.0.16028",
                     "systems": [
                         {

--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ build.lib_path={runtime.platform.path}/mtb-libs/libs/core-make.mtb
 # Compiler and toolchain paths
 # ---------
 
-compiler.mtb_lib_tools.path={runtime.tools.ModusToolbox.path}
+compiler.mtb_lib_tools.path={runtime.tools.mtb-tools.path}
 compiler.path={compiler.mtb_lib_tools.path}/gcc/bin/
 
 compiler.c.cmd=arm-none-eabi-gcc
@@ -126,7 +126,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.bin
 
 tools.openocd.upload.params.verbose=-v
 tools.openocd.upload.params.quiet=
-tools.openocd.upload.params.args=upload {runtime.tools.ModusToolbox.path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target.cfg} {build.project_name} {upload.verbose}
+tools.openocd.upload.params.args=upload {runtime.tools.mtb-tools.path} {runtime.platform.path} {build.path} {build.variant} {upload.port.properties.serialNumber} {upload.target.cfg} {build.project_name} {upload.verbose}
 
 tools.openocd.upload.pattern.linux=bash {runtime.platform.path}/tools/upload.sh {upload.params.args}
 tools.openocd.upload.pattern.windows={runtime.platform.path}/tools/upload.bat {upload.params.args}

--- a/tools/release.py
+++ b/tools/release.py
@@ -2,9 +2,9 @@ import argparse
 import copy
 import hashlib
 import json
+import os
 import re
 import requests
-import os
 import shutil
 
 version = "0.1.0"
@@ -14,6 +14,7 @@ build_dir_name = "pkg_build"
 pkg_assets_build_path = os.path.join(psoc_ino_root_path, build_dir_name)
 
 
+# Utility Functions
 def strip_prefix_from_version(version):
     return re.sub(r"[vV]", "", version)
 
@@ -22,22 +23,28 @@ def mkdir_package_dir(version):
     semver = strip_prefix_from_version(version)
     pkg_name = "PSOC_IFX_" + semver
     pkg_build_path = os.path.join(pkg_assets_build_path, pkg_name)
-    os.mkdir(pkg_build_path)
-
+    if os.path.exists(pkg_build_path):
+        shutil.rmtree(pkg_build_path)
+    os.makedirs(pkg_build_path)
     return pkg_name
 
 
+def get_package_size(pkg):
+    return os.path.getsize(pkg)
+
+
+def get_package_sha256(pkg):
+    with open(pkg, "rb") as f:
+        bytes = f.read()
+        hash = hashlib.sha256(bytes).hexdigest()
+    return hash
+
+
+# Package Building Functions
 def build_package(pkg_name):
     pkg_build_path = os.path.join(pkg_assets_build_path, pkg_name)
-
     dirs_to_copy = ["cores", "tools", "mtb-libs", "examples"]
-
-    files_to_copy = [
-        "boards.txt",
-        "platform.txt",
-        "LICENSE.md",
-        "README.md",
-    ]
+    files_to_copy = ["boards.txt", "platform.txt", "LICENSE.md", "README.md"]
 
     for dir in dirs_to_copy:
         shutil.copytree(
@@ -55,21 +62,10 @@ def zip_package(pkg_name):
     shutil.make_archive(pkg_build_path, "zip", pkg_assets_build_path, pkg_name)
 
 
-def get_package_size(pkg):
-    return os.path.getsize(pkg)
-
-
-def get_package_sha256(pkg):
-    with open(pkg, "rb") as f:
-        bytes = f.read()
-        hash = hashlib.sha256(bytes).hexdigest()
-
-    return hash
-
-
+# Package Index Management Functions
 def get_latest_package_index_json():
     return requests.get(
-        "https://github.com/Infineon/arduino-core-psoc/releases/download/0.0.0-none/package_psoc_index.json"
+        "https://github.com/Infineon/arduino-core-psoc/releases/download/0.1.0/package_psoc_index.json"
     ).json()
 
 
@@ -86,20 +82,27 @@ def get_platform_data_struct_copy(pkg_index):
     return copy.deepcopy(pkg_index["packages"][0]["platforms"])
 
 
-def set_new_platform_data_fields(platform_data_index, pkg_name, version, repository):
+def set_new_platform_data_fields(platform_data_index, pkg_name, version, repository=""):
     semver = strip_prefix_from_version(version)
     platform_data = platform_data_index["packages"][0]["platforms"][0]
     platform_data["version"] = str(semver)
     archive_file_name = str(pkg_name) + ".zip"
     platform_data["archiveFileName"] = archive_file_name
-    platform_data["url"] = (
-        "https://github.com/"
-        + str(repository)
-        + "/releases/download/"
-        + str(version)
-        + "/"
-        + str(archive_file_name)
-    )
+
+    if repository == "":
+        platform_data["url"] = (
+            os.path.join(os.getcwd(), build_dir_name) + "/" + str(archive_file_name)
+        )
+    else:
+        platform_data["url"] = (
+            "https://github.com/"
+            + str(repository)
+            + "/releases/download/"
+            + str(version)
+            + "/"
+            + str(archive_file_name)
+        )
+
     platform_data["checksum"] = "SHA-256:" + str(
         get_package_sha256(os.path.join(pkg_assets_build_path, archive_file_name))
     )
@@ -114,58 +117,65 @@ def add_platform_to_package_index(pkg_index, platform):
 
 def make_package_index_file(pkg_index):
     pkg_index_json_obj = json.dumps(pkg_index, indent=2)
-    pkg_index_w_path = os.path.join(
-        pkg_assets_build_path, "package_infineon_index.json"
-    )
+    pkg_index_w_path = os.path.join(pkg_assets_build_path, "package_psoc_index.json")
     with open(pkg_index_w_path, "w") as pkg_file:
         pkg_file.write(pkg_index_json_obj)
 
 
-def build_package_index_json(pkg_name, version, repository):
-    # get online package index json
-    latest_package_index = get_latest_package_index_json()
-    # get local package index template
+def build_package_index_json(pkg_name, version, repository, release=True):
     local_package_index = get_local_package_index_json()
-    # set data field in local template for newest package
     set_new_platform_data_fields(local_package_index, pkg_name, version, repository)
-    # get old package array
-    old_platform_data = get_platform_data_struct_copy(latest_package_index)
-    # append to local package index
-    add_platform_to_package_index(local_package_index, old_platform_data)
+
+    if release:
+        latest_package_index = get_latest_package_index_json()
+        old_platform_data = get_platform_data_struct_copy(latest_package_index)
+        add_platform_to_package_index(local_package_index, old_platform_data)
+
     make_package_index_file(local_package_index)
 
 
-def build_release_assets(version, repository):
+# Release Asset Management
+def build_release_assets(pkg_name):
     if os.path.exists(pkg_assets_build_path):
         shutil.rmtree(pkg_assets_build_path)
-    os.mkdir(pkg_assets_build_path)
-    pkg_name = mkdir_package_dir(version)
+    os.makedirs(pkg_assets_build_path)
     build_package(pkg_name)
     zip_package(pkg_name)
-    build_package_index_json(pkg_name, version, repository)
+
+
+# Argument Parsing Functions
+def main_parser_func(args):
+    parser.print_help()
+
+
+def parser_build_release_assets_func(args):
+    global psoc_ino_root_path
+    global pkg_build_path
+    psoc_ino_root_path = args.root_path
+    pkg_build_path = args.build_path
+    pkg_name = mkdir_package_dir(args.version)
+    build_release_assets(pkg_name)
+    build_package_index_json(pkg_name, args.version, args.repository)
+
+
+def parser_build_local_assets_func(args):
+    pkg_name = mkdir_package_dir(version)
+    build_release_assets(pkg_name)
+    build_package_index_json(pkg_name, version, "", False)
+
+
+class ver_action(argparse.Action):
+    def __init__(self, option_strings, dest, **kwargs):
+        super().__init__(
+            option_strings, dest, nargs=0, default=argparse.SUPPRESS, **kwargs
+        )
+
+    def __call__(self, parser, namespace, values, option_string, **kwargs):
+        print("psoc-release version: " + version)
+        parser.exit()
 
 
 def parser():
-    def main_parser_func(args):
-        parser.print_help()
-
-    def parser_build_release_assets_func(args):
-        global psoc_ino_root_path
-        global pkg_build_path
-        psoc_ino_root_path = args.root_path
-        pkg_build_path = args.build_path
-        build_release_assets(args.version, args.repository)
-
-    class ver_action(argparse.Action):
-        def __init__(self, option_strings, dest, **kwargs):
-            return super().__init__(
-                option_strings, dest, nargs=0, default=argparse.SUPPRESS, **kwargs
-            )
-
-        def __call__(self, parser, namespace, values, option_string, **kwargs):
-            print("psoc-release version: " + version)
-            parser.exit()
-
     # General parser
     parser = argparse.ArgumentParser(description="psoc-release tool")
     parser.add_argument(
@@ -197,6 +207,12 @@ def parser():
         help="Path to build package",
     )
     parser_release.set_defaults(func=parser_build_release_assets_func)
+
+    # Local parser
+    parser_local = subparser.add_parser(
+        "build-local", description="Build package locally"
+    )
+    parser_local.set_defaults(func=parser_build_local_assets_func)
 
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Extended the workflow to host a local server and consume the package json and package folder in Arduino installation.
With this approach:
1. we could avoid consuming the packages directly from releases. 
2. we perform sanity check of the package generation and package json generation.