### PR TITLE
Psoc ino interrupts

### DIFF
--- a/cores/psoc/Arduino.h
+++ b/cores/psoc/Arduino.h
@@ -21,7 +21,7 @@
 #define Arduino_h
 
 #include "api/ArduinoAPI.h"
-#include "cyhal.h"
+#include "cyhal_gpio.h"
 
 #define RAMSTART (HMCRAMC0_ADDR)
 #define RAMSIZE  (HMCRAMC0_SIZE)
@@ -34,17 +34,14 @@ using namespace arduino;
 extern "C" {
 #endif // __cplusplus
 
-// pin init configuration
-typedef struct {
-    cyhal_gpio_t pin; // GPIO pin
-    bool initValue;   // Initial value of the pin
-} pinInitConfig;
-
 // ****************************************************************************
 // @Imported Global Variables
 // ****************************************************************************
-extern const pinInitConfig mapping_gpio_pin[];
+extern const cyhal_gpio_t mapping_gpio_pin[];
 extern const uint8_t GPIO_PIN_COUNT;
+
+#define GPIO_INTERRUPT_PRIORITY 3 // GPIO interrupt priority
+#define digitalPinToInterrupt(p) ((p) < GPIO_PIN_COUNT ? (p) : -1)
 
 #undef LITTLE_ENDIAN
 

--- a/cores/psoc/Arduino.h
+++ b/cores/psoc/Arduino.h
@@ -21,6 +21,7 @@
 #define Arduino_h
 
 #include "api/ArduinoAPI.h"
+#include "cyhal.h"
 
 #define RAMSTART (HMCRAMC0_ADDR)
 #define RAMSIZE  (HMCRAMC0_SIZE)
@@ -33,7 +34,18 @@ using namespace arduino;
 extern "C" {
 #endif // __cplusplus
 
-// Include Atmel headers
+// pin init configuration
+typedef struct {
+    cyhal_gpio_t pin; // GPIO pin
+    bool initValue;   // Initial value of the pin
+} pinInitConfig;
+
+// ****************************************************************************
+// @Imported Global Variables
+// ****************************************************************************
+extern const pinInitConfig mapping_gpio_pin[];
+extern const uint8_t GPIO_PIN_COUNT;
+
 #undef LITTLE_ENDIAN
 
 #define clockCyclesPerMicrosecond() (SystemCoreClock / 1000000L)
@@ -52,11 +64,13 @@ extern "C" {
 
 #define abs(x) ((x) > 0?(x):-(x))
 
+// Globally enable or disable interrupts
+#define interrupts() __enable_irq()
+#define noInterrupts() __disable_irq()
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/cores/psoc/Uart.cpp
+++ b/cores/psoc/Uart.cpp
@@ -100,14 +100,14 @@ int Uart::peek(void) {
 }
 
 int Uart::read(void) {
-    __disable_irq();
+    noInterrupts();
     if (bufferHead == bufferTail) {
-        __enable_irq();
+        interrupts();
         return -1;                  // Buffer is empty
     } else {
         uint8_t c = buffer[bufferTail];
         bufferTail = (bufferTail + 1) % bufferSize;
-        __enable_irq();
+        interrupts();
         return c;
     }
 }

--- a/cores/psoc/Uart.h
+++ b/cores/psoc/Uart.h
@@ -10,7 +10,7 @@
 class Uart: public arduino::HardwareSerial
 {
 public:
-    static Uart *g_uarts[MAX_UARTS];
+    static Uart * g_uarts[MAX_UARTS];
     Uart(cyhal_gpio_t tx, cyhal_gpio_t rx, cyhal_gpio_t cts, cyhal_gpio_t rts);
     void begin(unsigned long baud);
     void begin(unsigned long baud, uint16_t config);

--- a/cores/psoc/Uart.h
+++ b/cores/psoc/Uart.h
@@ -10,7 +10,7 @@
 class Uart: public arduino::HardwareSerial
 {
 public:
-    static Uart * g_uarts[MAX_UARTS];
+    static Uart *g_uarts[MAX_UARTS];
     Uart(cyhal_gpio_t tx, cyhal_gpio_t rx, cyhal_gpio_t cts, cyhal_gpio_t rts);
     void begin(unsigned long baud);
     void begin(unsigned long baud, uint16_t config);

--- a/cores/psoc/digital_io.c
+++ b/cores/psoc/digital_io.c
@@ -31,6 +31,7 @@ void pinMode(pin_size_t pin, PinMode mode) {
 
     cyhal_gpio_direction_t direction;
     cyhal_gpio_drive_mode_t drive_mode;
+    bool initPinValue = false;
 
     switch (mode)
     {
@@ -42,6 +43,7 @@ void pinMode(pin_size_t pin, PinMode mode) {
         case INPUT_PULLUP:
             direction = CYHAL_GPIO_DIR_INPUT;
             drive_mode = CYHAL_GPIO_DRIVE_PULLUP;
+            initPinValue = true;
             break;
 
         case INPUT_PULLDOWN:
@@ -63,16 +65,16 @@ void pinMode(pin_size_t pin, PinMode mode) {
             return; // Invalid mode
     }
 
-    // Initialize the GPIO pin with the specified direction, drive mode and set initial value = false (low)
-    (void)cyhal_gpio_init(mapping_gpio_pin[pin].pin, direction, drive_mode, mapping_gpio_pin[pin].initValue);
+    // Initialize the GPIO pin with the specified direction, drive mode and set initial value
+    (void)cyhal_gpio_init(mapping_gpio_pin[pin], direction, drive_mode, initPinValue);
 }
 
 uint8_t digitalRead(uint8_t pin) {
-    return cyhal_gpio_read(mapping_gpio_pin[pin].pin) ? HIGH : LOW;
+    return cyhal_gpio_read(mapping_gpio_pin[pin]) ? HIGH : LOW;
 }
 
 void digitalWrite(uint8_t pin, uint8_t value) {
-    cyhal_gpio_write(mapping_gpio_pin[pin].pin, value);
+    cyhal_gpio_write(mapping_gpio_pin[pin], value);
 }
 
 #ifdef __cplusplus

--- a/cores/psoc/digital_io.c
+++ b/cores/psoc/digital_io.c
@@ -16,7 +16,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#define ARDUINO_GPIO
 #include "Arduino.h"
 
 #ifdef __cplusplus
@@ -65,15 +64,15 @@ void pinMode(pin_size_t pin, PinMode mode) {
     }
 
     // Initialize the GPIO pin with the specified direction, drive mode and set initial value = false (low)
-    (void)cyhal_gpio_init(mapping_gpio_pin[pin], direction, drive_mode, false);
+    (void)cyhal_gpio_init(mapping_gpio_pin[pin].pin, direction, drive_mode, mapping_gpio_pin[pin].initValue);
 }
 
 uint8_t digitalRead(uint8_t pin) {
-    return cyhal_gpio_read(mapping_gpio_pin[pin]) ? HIGH : LOW;
+    return cyhal_gpio_read(mapping_gpio_pin[pin].pin) ? HIGH : LOW;
 }
 
 void digitalWrite(uint8_t pin, uint8_t value) {
-    cyhal_gpio_write(mapping_gpio_pin[pin], value);
+    cyhal_gpio_write(mapping_gpio_pin[pin].pin, value);
 }
 
 #ifdef __cplusplus

--- a/cores/psoc/interrupts.c
+++ b/cores/psoc/interrupts.c
@@ -1,0 +1,74 @@
+/*
+  Copyright (c) 2015 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// ****************************************************************************
+// @Project Includes
+// ****************************************************************************
+#include "Arduino.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static cyhal_gpio_callback_data_t gpio_callback_data;
+
+void attachInterrupt(pin_size_t interruptNumber, voidFuncPtr callback, PinStatus mode) {
+    if ((interruptNumber >= GPIO_PIN_COUNT) || (digitalPinToInterrupt(interruptNumber) < 0)) {
+        return; // Invalid interrupt number
+    }
+
+    cyhal_gpio_event_t event;
+    cyhal_gpio_t pin = mapping_gpio_pin[interruptNumber].pin;
+
+    switch (mode) {
+        case CHANGE:
+            event = CYHAL_GPIO_IRQ_BOTH;
+            break;
+
+        case RISING:
+            event = CYHAL_GPIO_IRQ_RISE;
+            break;
+
+        case FALLING:
+            event = CYHAL_GPIO_IRQ_FALL;
+            break;
+
+        default:
+            event = CYHAL_GPIO_IRQ_NONE;
+            break;
+    }
+
+    gpio_callback_data.callback = callback;
+    cyhal_gpio_register_callback(pin, &gpio_callback_data);
+    cyhal_gpio_enable_event(pin, event, GPIO_INTERRUPT_PRIORITY, true);
+}
+
+void detachInterrupt(pin_size_t interruptNumber) {
+
+    if ((interruptNumber >= GPIO_PIN_COUNT) || (digitalPinToInterrupt(interruptNumber) < 0)) {
+        return; // Invalid interrupt number
+    }
+
+    cyhal_gpio_t pin = mapping_gpio_pin[interruptNumber].pin;
+    cyhal_gpio_enable_event(pin, CYHAL_GPIO_IRQ_NONE, 0, false);
+    cyhal_gpio_register_callback(pin, NULL);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cores/psoc/interrupts.c
+++ b/cores/psoc/interrupts.c
@@ -33,7 +33,7 @@ void attachInterrupt(pin_size_t interruptNumber, voidFuncPtr callback, PinStatus
     }
 
     cyhal_gpio_event_t event;
-    cyhal_gpio_t pin = mapping_gpio_pin[interruptNumber].pin;
+    cyhal_gpio_t pin = mapping_gpio_pin[interruptNumber];
 
     switch (mode) {
         case CHANGE:
@@ -64,7 +64,7 @@ void detachInterrupt(pin_size_t interruptNumber) {
         return; // Invalid interrupt number
     }
 
-    cyhal_gpio_t pin = mapping_gpio_pin[interruptNumber].pin;
+    cyhal_gpio_t pin = mapping_gpio_pin[interruptNumber];
     cyhal_gpio_enable_event(pin, CYHAL_GPIO_IRQ_NONE, 0, false);
     cyhal_gpio_register_callback(pin, NULL);
 }

--- a/cores/psoc/main.cpp
+++ b/cores/psoc/main.cpp
@@ -20,7 +20,6 @@
 
 #include "Arduino.h"
 
-#include "cyhal.h"
 #include "cybsp.h"
 #include "cy_retarget_io.h"
 #include "time.h"

--- a/cores/psoc/main.cpp
+++ b/cores/psoc/main.cpp
@@ -16,6 +16,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#define ARDUINO_GPIO
+
 #include "Arduino.h"
 
 #include "cyhal.h"
@@ -46,7 +48,7 @@ int main(void) {
     }
 
     /* Enable global interrupts */
-    __enable_irq();
+    interrupts();
     initVariant();
     setup();
 

--- a/examples/blinkLEDWithInterrupt/blinkLEDWithInterrupt.ino
+++ b/examples/blinkLEDWithInterrupt/blinkLEDWithInterrupt.ino
@@ -1,0 +1,22 @@
+volatile bool ledState = HIGH;
+
+void toggleLED() {
+    ledState = !ledState; 
+    digitalWrite(LED_BUILTIN, ledState);
+}
+
+
+void setup() {
+    Serial.begin(112500);
+    Serial.println("LED toggles with USER_BUTTON interrupt at Falling edge!");
+
+    pinMode(USER_BUTTON, INPUT_PULLUP); 
+    pinMode(LED_BUILTIN, OUTPUT); 
+
+    // Attach interrupt to the button pin
+    attachInterrupt(USER_BUTTON, toggleLED, FALLING); 
+}
+
+void loop() {
+    // Do nothing
+}

--- a/examples/testSketch/testSketch.ino
+++ b/examples/testSketch/testSketch.ino
@@ -2,15 +2,17 @@
 
 // the setup function runs once when you press reset or power the board
 void setup() {
-
+  Serial.begin(112500);
+  Serial.println("LED toggles first with 1 second delay and next with 0.5 seconds delay!");
+  
   pinMode(LED_BUILTIN, OUTPUT);
 }
 
 // the loop function runs over and over again forever
 void loop() {
-  digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
+  digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on
   delay(1000); // Delay for 1000 milliseconds (1 second)
-  digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
+  digitalWrite(LED_BUILTIN, LOW);    // turn the LED off
   delay(1000); // Delay for 1000 milliseconds (1 second)
 
   // Toggle the LED using delayMicroseconds

--- a/tests/test_config.h
+++ b/tests/test_config.h
@@ -14,7 +14,6 @@
 
 // test defines
 const uint8_t TEST_DIGITALIO_OUTPUT = 7;  // IO0
-const uint8_t TEST_DIGITALIO_INPUT_1 = 6; // IO1
-const uint8_t TEST_DIGITALIO_INPUT_2 = 5; // IO2
+const uint8_t TEST_DIGITALIO_INPUT = 6;   // IO1
 
 #endif // TEST_CONFIG_H

--- a/variants/CY8CKIT-062S2-AI/pins_arduino.h
+++ b/variants/CY8CKIT-062S2-AI/pins_arduino.h
@@ -45,6 +45,10 @@
 #define BUTTON1 14            // Additional BUTTON1
 #define USER_BUTTON BUTTON1   // Standard Arduino USER_BUTTON: Uses BUTTON1
 
+#define GPIO_INTERRUPT_PRIORITY 3 // GPIO interrupt priority
+
+#define digitalPinToInterrupt(p) ((p) < GPIO_PIN_COUNT ? (p) : -1)
+
 //****************************************************************************
 
 #ifdef ARDUINO_GPIO
@@ -54,45 +58,45 @@ extern "C" {
 #endif
 
 // Mapping of digital pins and comments
-const cyhal_gpio_t mapping_gpio_pin[] = {
-    /* 0  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 0),  // SPI-MOSI                       P9.0 
-    /* 1  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 1),  // SPI-MISO                       P9.1
-    /* 2  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 2),  // SPI-SCLK                       P9.2
-    /* 3  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 3),  // IO_0                           P9.3
-    /* 4  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 4),  // IO_1                           P9.4
-    /* 5  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 5),  // IO_2 / PWM1                    P9.5 
-    /* 6  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 6),  // IO_3 / PWM2                    P9.6
-    /* 7  */ CYHAL_GET_GPIO(CYHAL_PORT_9, 7),  // IO_4                           P9.7
-
-    /* 8  */ CYHAL_GET_GPIO(CYHAL_PORT_0, 2),  // I2C-SCL                        P0.2
-    /* 9  */ CYHAL_GET_GPIO(CYHAL_PORT_0, 3),  // I2C-SDA                        P0.3
-    /* 10 */ CYHAL_GET_GPIO(CYHAL_PORT_10, 1), // A1 / UART_TX                   P10.1
-    /* 11 */ CYHAL_GET_GPIO(CYHAL_PORT_10, 0), // A0 / UART_RX                   P10.0
+const pinInitConfig mapping_gpio_pin[] = {
+    /* 0   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 0),  false},  // SPI-MOSI        P9.0 
+    /* 1   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 1),  false},  // SPI-MISO        P9.1
+    /* 2   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 2),  false},  // SPI-SCLK        P9.2
+    /* 3   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 3),  false},  // IO_0            P9.3
+    /* 4   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 4),  false},  // IO_1            P9.4
+    /* 5   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 5),  false},  // IO_2 / PWM1     P9.5 
+    /* 6   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 6),  false},  // IO_3 / PWM2     P9.6
+    /* 7   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 7),  false},  // IO_4            P9.7
+		   
+    /* 8   */ {CYHAL_GET_GPIO(CYHAL_PORT_0, 2),  false},  // I2C-SCL         P0.2
+    /* 9   */ {CYHAL_GET_GPIO(CYHAL_PORT_0, 3),  false},  // I2C-SDA         P0.3
+    /* 10  */ {CYHAL_GET_GPIO(CYHAL_PORT_10, 1), false},  // A1 / UART_TX    P10.1
+    /* 11  */ {CYHAL_GET_GPIO(CYHAL_PORT_10, 0), false},  // A0 / UART_RX    P10.0
 
     // on board LEDs and USER BUTTON
 
-    /* 12  */ CYHAL_GET_GPIO(CYHAL_PORT_5, 3),  // LED1                          P8.2
-    /* 13  */ CYHAL_GET_GPIO(CYHAL_PORT_5, 4),  // LED2                          P8.1
-    /* 14  */ CYHAL_GET_GPIO(CYHAL_PORT_5, 2),  // USER BUTTON                   P8.0 
+    /* 12  */ {CYHAL_GET_GPIO(CYHAL_PORT_5, 3),CYBSP_LED_STATE_OFF},           // LED1                     P5.3
+    /* 13  */ {CYHAL_GET_GPIO(CYHAL_PORT_5, 4),CYBSP_LED_STATE_OFF},           // LED2                     P5.4
+    /* 14  */ {CYHAL_GET_GPIO(CYHAL_PORT_5, 2),CYBSP_BTN_OFF},                 // USER BUTTON              P5.2 
 
     // Additional pins for expansion IO connector - J15 starting here
 
-    /* 15  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 0), // SDHC_DATA00 / SPI-MOSI / UART_RX / I2C-SCL     P13.0
-    /* 16  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 1), // SDHC_DATA01 / SPI-MISO / UART_TX / I2C-SDA     P13.1
-    /* 17  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 2), // SDHC_DATA02 / SPI-SCLK / IO / PWM              P13.2
-    /* 18  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 3), // SDHC_DATA03 / IO / PWM                         P13.3
-    /* 19  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 4), // SDHC_DATA10 / UART_RX / I2C-SCL                P13.4
-    /* 20  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 5), // SDHC_DATA11 / UART_TX / I2C-SDA                P13.5
-    /* 21  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 6), // SDHC_DATA12 / IO / PWM                         P13.6
-    /* 22  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 7), // SDHC_DATA13 / IO / PWM                         P13.7
-    /* 23  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 2),  // SPI-SCLK / IO /PWM                             P8.2
-    /* 24  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 1),  // SPI-MISO / UART_TX / I2C-SDA / IO / PWM        P8.1
-    /* 25  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 0),  // SPI-MOSI / UART_RX / I2C-SCL / IO / PWM        P8.0   
-    /* 26  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 3),  // IO / PWM                                       P8.3 
-    /* 27  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 4),  // UART_RX / I2C-SCL / IO /PWM                    P8.4 
-    /* 28  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 5),  // UART_TX / I2C-SDA / IO /PWM                    P8.5 
-    /* 29  */ CYHAL_GET_GPIO(CYHAL_PORT_12, 4), // SDHC_CMD / IO /PWM                             P12.4 
-    /* 30  */ CYHAL_GET_GPIO(CYHAL_PORT_12, 5), // SDHC_CLK / IO /PWM                             P12.5
+    /* 15  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 0), false}, // SDHC_DATA00 / SPI-MOSI / UART_RX / I2C-SCL     P13.0
+    /* 16  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 1), false}, // SDHC_DATA01 / SPI-MISO / UART_TX / I2C-SDA     P13.1
+    /* 17  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 2), false}, // SDHC_DATA02 / SPI-SCLK / IO / PWM              P13.2
+    /* 18  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 3), false}, // SDHC_DATA03 / IO / PWM                         P13.3
+    /* 19  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 4), false}, // SDHC_DATA10 / UART_RX / I2C-SCL                P13.4
+    /* 20  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 5), false}, // SDHC_DATA11 / UART_TX / I2C-SDA                P13.5
+    /* 21  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 6), false}, // SDHC_DATA12 / IO / PWM                         P13.6
+    /* 22  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 7), false}, // SDHC_DATA13 / IO / PWM                         P13.7
+    /* 23  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 2),  false}, // SPI-SCLK / IO /PWM                             P8.2
+    /* 24  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 1),  false}, // SPI-MISO / UART_TX / I2C-SDA / IO / PWM        P8.1
+    /* 25  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 0),  false}, // SPI-MOSI / UART_RX / I2C-SCL / IO / PWM        P8.0   
+    /* 26  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 3),  false}, // IO / PWM                                       P8.3 
+    /* 27  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 4),  false}, // UART_RX / I2C-SCL / IO /PWM                    P8.4 
+    /* 28  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 5),  false}, // UART_TX / I2C-SDA / IO /PWM                    P8.5 
+    /* 29  */ {CYHAL_GET_GPIO(CYHAL_PORT_12, 4), false}, // SDHC_CMD / IO /PWM                             P12.4 
+    /* 30  */ {CYHAL_GET_GPIO(CYHAL_PORT_12, 5), false}, // SDHC_CLK / IO /PWM                             P12.5
 };
 
 const uint8_t GPIO_PIN_COUNT = (sizeof(mapping_gpio_pin) / sizeof(mapping_gpio_pin[0])) - 1;

--- a/variants/CY8CKIT-062S2-AI/pins_arduino.h
+++ b/variants/CY8CKIT-062S2-AI/pins_arduino.h
@@ -45,10 +45,6 @@
 #define BUTTON1 14            // Additional BUTTON1
 #define USER_BUTTON BUTTON1   // Standard Arduino USER_BUTTON: Uses BUTTON1
 
-#define GPIO_INTERRUPT_PRIORITY 3 // GPIO interrupt priority
-
-#define digitalPinToInterrupt(p) ((p) < GPIO_PIN_COUNT ? (p) : -1)
-
 //****************************************************************************
 
 #ifdef ARDUINO_GPIO
@@ -58,45 +54,45 @@ extern "C" {
 #endif
 
 // Mapping of digital pins and comments
-const pinInitConfig mapping_gpio_pin[] = {
-    /* 0   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 0),  false},  // SPI-MOSI        P9.0 
-    /* 1   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 1),  false},  // SPI-MISO        P9.1
-    /* 2   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 2),  false},  // SPI-SCLK        P9.2
-    /* 3   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 3),  false},  // IO_0            P9.3
-    /* 4   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 4),  false},  // IO_1            P9.4
-    /* 5   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 5),  false},  // IO_2 / PWM1     P9.5 
-    /* 6   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 6),  false},  // IO_3 / PWM2     P9.6
-    /* 7   */ {CYHAL_GET_GPIO(CYHAL_PORT_9, 7),  false},  // IO_4            P9.7
+const cyhal_gpio_t mapping_gpio_pin[] = {
+    /* 0   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 0),  // SPI-MOSI        P9.0 
+    /* 1   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 1),  // SPI-MISO        P9.1
+    /* 2   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 2),  // SPI-SCLK        P9.2
+    /* 3   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 3),  // IO_0            P9.3
+    /* 4   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 4),  // IO_1            P9.4
+    /* 5   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 5),  // IO_2 / PWM1     P9.5 
+    /* 6   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 6),  // IO_3 / PWM2     P9.6
+    /* 7   */ CYHAL_GET_GPIO(CYHAL_PORT_9, 7),  // IO_4            P9.7
 		   
-    /* 8   */ {CYHAL_GET_GPIO(CYHAL_PORT_0, 2),  false},  // I2C-SCL         P0.2
-    /* 9   */ {CYHAL_GET_GPIO(CYHAL_PORT_0, 3),  false},  // I2C-SDA         P0.3
-    /* 10  */ {CYHAL_GET_GPIO(CYHAL_PORT_10, 1), false},  // A1 / UART_TX    P10.1
-    /* 11  */ {CYHAL_GET_GPIO(CYHAL_PORT_10, 0), false},  // A0 / UART_RX    P10.0
+    /* 8   */ CYHAL_GET_GPIO(CYHAL_PORT_0, 2),  // I2C-SCL         P0.2
+    /* 9   */ CYHAL_GET_GPIO(CYHAL_PORT_0, 3),  // I2C-SDA         P0.3
+    /* 10  */ CYHAL_GET_GPIO(CYHAL_PORT_10, 1), // A1 / UART_TX    P10.1
+    /* 11  */ CYHAL_GET_GPIO(CYHAL_PORT_10, 0), // A0 / UART_RX    P10.0
 
     // on board LEDs and USER BUTTON
 
-    /* 12  */ {CYHAL_GET_GPIO(CYHAL_PORT_5, 3),CYBSP_LED_STATE_OFF},           // LED1                     P5.3
-    /* 13  */ {CYHAL_GET_GPIO(CYHAL_PORT_5, 4),CYBSP_LED_STATE_OFF},           // LED2                     P5.4
-    /* 14  */ {CYHAL_GET_GPIO(CYHAL_PORT_5, 2),CYBSP_BTN_OFF},                 // USER BUTTON              P5.2 
+    /* 12  */ CYHAL_GET_GPIO(CYHAL_PORT_5, 3),  // LED1            P5.3
+    /* 13  */ CYHAL_GET_GPIO(CYHAL_PORT_5, 4),  // LED2            P5.4
+    /* 14  */ CYHAL_GET_GPIO(CYHAL_PORT_5, 2),  // USER BUTTON     P5.2 
 
     // Additional pins for expansion IO connector - J15 starting here
 
-    /* 15  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 0), false}, // SDHC_DATA00 / SPI-MOSI / UART_RX / I2C-SCL     P13.0
-    /* 16  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 1), false}, // SDHC_DATA01 / SPI-MISO / UART_TX / I2C-SDA     P13.1
-    /* 17  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 2), false}, // SDHC_DATA02 / SPI-SCLK / IO / PWM              P13.2
-    /* 18  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 3), false}, // SDHC_DATA03 / IO / PWM                         P13.3
-    /* 19  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 4), false}, // SDHC_DATA10 / UART_RX / I2C-SCL                P13.4
-    /* 20  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 5), false}, // SDHC_DATA11 / UART_TX / I2C-SDA                P13.5
-    /* 21  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 6), false}, // SDHC_DATA12 / IO / PWM                         P13.6
-    /* 22  */ {CYHAL_GET_GPIO(CYHAL_PORT_13, 7), false}, // SDHC_DATA13 / IO / PWM                         P13.7
-    /* 23  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 2),  false}, // SPI-SCLK / IO /PWM                             P8.2
-    /* 24  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 1),  false}, // SPI-MISO / UART_TX / I2C-SDA / IO / PWM        P8.1
-    /* 25  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 0),  false}, // SPI-MOSI / UART_RX / I2C-SCL / IO / PWM        P8.0   
-    /* 26  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 3),  false}, // IO / PWM                                       P8.3 
-    /* 27  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 4),  false}, // UART_RX / I2C-SCL / IO /PWM                    P8.4 
-    /* 28  */ {CYHAL_GET_GPIO(CYHAL_PORT_8, 5),  false}, // UART_TX / I2C-SDA / IO /PWM                    P8.5 
-    /* 29  */ {CYHAL_GET_GPIO(CYHAL_PORT_12, 4), false}, // SDHC_CMD / IO /PWM                             P12.4 
-    /* 30  */ {CYHAL_GET_GPIO(CYHAL_PORT_12, 5), false}, // SDHC_CLK / IO /PWM                             P12.5
+    /* 15  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 0), // SDHC_DATA00 / SPI-MOSI / UART_RX / I2C-SCL     P13.0
+    /* 16  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 1), // SDHC_DATA01 / SPI-MISO / UART_TX / I2C-SDA     P13.1
+    /* 17  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 2), // SDHC_DATA02 / SPI-SCLK / IO / PWM              P13.2
+    /* 18  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 3), // SDHC_DATA03 / IO / PWM                         P13.3
+    /* 19  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 4), // SDHC_DATA10 / UART_RX / I2C-SCL                P13.4
+    /* 20  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 5), // SDHC_DATA11 / UART_TX / I2C-SDA                P13.5
+    /* 21  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 6), // SDHC_DATA12 / IO / PWM                         P13.6
+    /* 22  */ CYHAL_GET_GPIO(CYHAL_PORT_13, 7), // SDHC_DATA13 / IO / PWM                         P13.7
+    /* 23  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 2), // SPI-SCLK / IO /PWM                              P8.2
+    /* 24  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 1), // SPI-MISO / UART_TX / I2C-SDA / IO / PWM         P8.1
+    /* 25  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 0), // SPI-MOSI / UART_RX / I2C-SCL / IO / PWM         P8.0   
+    /* 26  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 3), // IO / PWM                                        P8.3 
+    /* 27  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 4), // UART_RX / I2C-SCL / IO /PWM                     P8.4 
+    /* 28  */ CYHAL_GET_GPIO(CYHAL_PORT_8, 5), // UART_TX / I2C-SDA / IO /PWM                     P8.5 
+    /* 29  */ CYHAL_GET_GPIO(CYHAL_PORT_12, 4), // SDHC_CMD / IO /PWM                             P12.4 
+    /* 30  */ CYHAL_GET_GPIO(CYHAL_PORT_12, 5), // SDHC_CLK / IO /PWM                             P12.5
 };
 
 const uint8_t GPIO_PIN_COUNT = (sizeof(mapping_gpio_pin) / sizeof(mapping_gpio_pin[0])) - 1;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Implementation of GPIO interrupt.
Test can be run locally with "make FQBN=infineon:psoc:cy8ckit_062s2_ai PORT=/dev/ttyACM0 test_interrupts_single" command using the arduino-core-test branch "https://github.com/Infineon/arduino-core-tests/tree/add-gpio-interrupt-tests"
Note: Pin 7 and 6 needs to be shorted.

There are some changes in arduino-core-test which needs to be merged for digital IO hil test to pass.

Also there is an example code blinkLEDWithInterrupt.ino which blinks LED with USER BUTTON press.