### PR TITLE
Wifi client and server read and write

### DIFF
--- a/libraries/WiFi/src/Socket.h
+++ b/libraries/WiFi/src/Socket.h
@@ -5,6 +5,7 @@
 
 #include "cy_secure_sockets.h"
 #include "IPAddress.h"
+#include "RingBuffer.h"  
 
 typedef enum {
     SOCKET_STATUS_UNINITED = 0,
@@ -20,21 +21,24 @@ typedef enum {
 class Socket {
 
     public:
+
         Socket();
 
         void begin();
         void end();
 
         void set_timeout(uint32_t timeout);
-        void set_connect_opts(cy_socket_callback_t cback, void *arg);
-        void set_receive_opts(cy_socket_callback_t cback, void *arg);
-        void set_disconnect_opts(cy_socket_callback_t cback, void *arg);
+        void set_connect_opt_callback(cy_socket_callback_t cback, void * arg);
+        void set_receive_opt_callback(cy_socket_callback_t cback, void * arg);
 
         void bind(uint16_t port);
         bool connect(IPAddress ip, uint16_t port);
         
         void listen(int max_connections);
         bool accept(Socket & client_socket);
+        uint32_t send(const void * data, uint32_t len);
+        uint32_t available();
+        uint32_t receive(uint8_t * data, uint32_t len);
 
         uint8_t status();
         cy_rslt_t get_last_error();
@@ -45,6 +49,12 @@ class Socket {
         socket_status_t s_status;
         cy_rslt_t s_last_error;
 
+        void set_opt_callback(int optname, cy_socket_callback_t cback, void * arg);
+
+        static const uint16_t RX_BUFFER_SIZE = 256;
+        arduino::RingBufferN<RX_BUFFER_SIZE> rx_buf;
+
+        void receive_callback();
 
         static bool global_socket_initialized;
         static uint32_t global_socket_count;

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -15,40 +15,53 @@
 }
 
 WiFiClient::WiFiClient() {
-
+   
 }
 
 int WiFiClient::connect(IPAddress ip, uint16_t port) {
     socket.begin();
     
-    socket.set_receive_opts(tcp_receive_msg_handler, this);
-    socket.set_disconnect_opts(tcp_disconnection_handler, this);
+    socket.set_receive_opt_callback(receive_callback, this); 
 
     return socket.connect(ip, port);
 }
 
 int WiFiClient::connect(const char *host, uint16_t port) {
+    /*TODO: First we need to get host by name in WiFi class */
     return 0;
 }
 
-size_t WiFiClient::write(uint8_t) {
-    return 0;
+size_t WiFiClient::write(uint8_t data) {
+    return write(&data, 1);
 }
 
 size_t WiFiClient::write(const uint8_t *buf, size_t size) {
-    return 0;
+    return (size_t)socket.send(buf, size);
 }
 
 int WiFiClient::available() {
-    return true;
+    return socket.available();
 }
 
 int WiFiClient::read()  {
-    return 0;
+    uint8_t data;
+    uint32_t received_data = socket.receive(&data, 1);
+
+    if(received_data == 0) {
+        return -1;
+    }
+
+    return (int)data;
 }
 
 int WiFiClient::read(uint8_t *buf, size_t size) {
-    return 0;   
+    uint32_t received_data = socket.receive(buf, size);
+
+    if(received_data == 0) {
+        return -1;
+    }
+
+    return (int)received_data;
 }
 
 int WiFiClient::peek() {
@@ -75,18 +88,16 @@ WiFiClient::operator bool() {
     if (socket.status() != SOCKET_STATUS_CONNECTED) {
         return false;
     }
-    if(available() <= 0) 
-    {
+    if(available() <= 0) {
         return false;
     }
     return true;
 }
 
-cy_rslt_t WiFiClient::tcp_receive_msg_handler(cy_socket_t socket_handle, void *arg) {
-    return 0;
-}
+cy_rslt_t WiFiClient::receive_callback(cy_socket_t socket_handle, void * arg) {
+    WiFiClient *client = (WiFiClient *)arg;
 
-cy_rslt_t WiFiClient::tcp_disconnection_handler(cy_socket_t socket_handle, void *arg) {
-    
-    return 0;
+    client->socket.receive_callback();
+
+    return CY_RSLT_SUCCESS;
 }

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -4,7 +4,6 @@
 
 #include <Socket.h>
 #include "Client.h"
-#include "cy_secure_sockets.h"
 
 class WiFiClient : arduino::Client {
 
@@ -13,7 +12,7 @@ class WiFiClient : arduino::Client {
 
         int connect(IPAddress ip, uint16_t port);
         int connect(const char *host, uint16_t port);
-        size_t write(uint8_t);
+        size_t write(uint8_t data);
         size_t write(const uint8_t *buf, size_t size);
         int available();
         int read();
@@ -29,8 +28,7 @@ class WiFiClient : arduino::Client {
     private:
         Socket socket;
 
-        static cy_rslt_t tcp_receive_msg_handler(cy_socket_t socket_handle, void *arg);
-        static cy_rslt_t tcp_disconnection_handler(cy_socket_t socket_handle, void *arg);
+        static cy_rslt_t receive_callback(cy_socket_t socket_handle, void * arg);
 
         friend class WiFiServer;
 };

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -13,9 +13,8 @@ void WiFiServer::begin(uint16_t port) {
     socket.begin();
     
     socket.set_timeout(SERVER_RECV_TIMEOUT_MS);
-    socket.set_connect_opts(tcp_connection_handler, this);
-    socket.set_receive_opts(tcp_receive_msg_handler, this);
-    socket.set_disconnect_opts(tcp_disconnection_handler, this);
+    socket.set_connect_opt_callback(connection_callback, this);
+    socket.set_receive_opt_callback(receive_callback, this);
 
     socket.bind(port);
     socket.listen(SERVER_MAX_CLIENTS);
@@ -30,7 +29,18 @@ WiFiClient WiFiServer::available() {
 
     if (connected_clients.size() > 0) {
         client = connected_clients.front();
-        connected_clients.erase(connected_clients.begin());
+        /* If client connected and data available */
+        if (client) {
+            return client;
+        }
+
+        //We cannot delete it, because we have to keep in the 
+        // list for received connections. 
+        // We can only deleted from the list when disconnecting.
+        // connected_clients.erase(connected_clients.begin());
+        /**
+         * TODO: We need to check later how to handle the client
+         * removal from the list upon disconnection etc.*/
     }
 
     return client;
@@ -51,15 +61,12 @@ void WiFiServer::end() {
     socket.end();
 }
 
-
-cy_rslt_t WiFiServer::tcp_connection_handler(cy_socket_t socket_handle, void *arg) {
-    
+cy_rslt_t WiFiServer::connection_callback(cy_socket_t socket_handle, void *arg) {
     WiFiServer *server = (WiFiServer *)arg;
 
     WiFiClient new_client;
-
     if(!server->socket.accept(new_client.socket)) {
-        return CY_RSLT_MODULE_SECURE_SOCKETS_NOMEM;
+        return server->socket.get_last_error();
     }
 
     server->connected_clients.push_back(new_client);
@@ -67,12 +74,20 @@ cy_rslt_t WiFiServer::tcp_connection_handler(cy_socket_t socket_handle, void *ar
     return CY_RSLT_SUCCESS;
 }
 
-cy_rslt_t WiFiServer::tcp_receive_msg_handler(cy_socket_t socket_handle, void *arg) {
+cy_rslt_t WiFiServer::receive_callback(cy_socket_t socket_handle, void * arg) {
+    WiFiServer *server = (WiFiServer *)arg;
 
-    return 0;
-}
+    /** 
+     * Find the client which has triggered the callback
+     * and receive the data from the client. 
+     */
+    std::vector<WiFiClient>::iterator client = server->connected_clients.begin();    
+    for( ;client != server->connected_clients.end(); client++) {
+        if(client->socket.socket == socket_handle) {
+            client->socket.receive_callback();
+            break;
+        }
+    }
 
-cy_rslt_t WiFiServer::tcp_disconnection_handler(cy_socket_t socket_handle, void *arg) {
-    
-    return 0;
+    return CY_RSLT_SUCCESS;
 }

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -21,20 +21,17 @@ class WiFiServer : public arduino::Server {
 
         void end();
 
-        static uint32_t connect_callback_count;
-
     private:
+
+        Socket socket;
 
         static const uint16_t SERVER_RECV_TIMEOUT_MS = 500;
         static const uint32_t SERVER_MAX_CLIENTS = 255;
 
-        Socket socket;
-
         std::vector <WiFiClient> connected_clients;
 
-        static cy_rslt_t tcp_connection_handler(cy_socket_t socket_handle, void *arg);
-        static cy_rslt_t tcp_receive_msg_handler(cy_socket_t socket_handle, void *arg);
-        static cy_rslt_t tcp_disconnection_handler(cy_socket_t socket_handle, void *arg);
+        static cy_rslt_t connection_callback(cy_socket_t socket_handle, void * arg);
+        static cy_rslt_t receive_callback(cy_socket_t socket_handle, void * arg);
 };
 
 #endif /* WIFI_SERVER_H */


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

This PR enables the write() and read() function from both WiFiClient and WiFiServer. 

The relationship between server and client and how the sockets handle the reception depending on the role 
require to set a different callback depending if:
* The client instance is using connect() to connect to a server. 
* The client instance is one of the server side connected clients. 

The tests in this PR -> https://github.com/Infineon/arduino-core-tests/pull/12

![image](https://github.com/user-attachments/assets/a1b52192-5630-4f06-98df-03a2cad19415)

Also, as required some refactors and modification on the Socket class. 
